### PR TITLE
append querystring

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
-module.exports = function canonical () {
+module.exports = function canonical(opts){
   var tags = document.getElementsByTagName('link');
+  var opts = opts || { qs: '' };
+
   for (var i = 0, tag; tag = tags[i]; i++) {
-    if ('canonical' == tag.getAttribute('rel')) return tag.getAttribute('href');
+    if ('canonical' != tag.getAttribute('rel')) continue;
+    var url = tag.getAttribute('href');
+    if (~url.indexOf('?')) return url;
+    return url + opts.qs;
   }
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,17 +1,33 @@
 describe('canonical', function () {
   var canonical = require('canonical')
-    , assert    = require('component-assert');
+    , assert    = require('component-assert')
+    , link
+    , url;
 
   it('matches nothing', function () {
     assert(undefined === canonical());
   });
 
   it('matches something', function () {
-    var link = document.createElement('link');
-    link.rel = 'canonical';
-    var url = link.href = '/index.html';
-    document.head.appendChild(link);
-
-    assert(url === canonical());
+    create(url = '/index.html');
+    assert(url == canonical());
+    remove();
   });
+
+  it('should get the query string from document.location.search if it doesnt include it', function(){
+    create(url = '/index.html');
+    assert('/index.html?querystring' == canonical({ qs: '?querystring' }));
+    remove();
+  })
+
+  function create(url){
+    link = document.createElement('link');
+    link.rel = 'canonical';
+    var url = link.href = url;
+    document.head.appendChild(link);
+  }
+
+  function remove(){
+    link.parentNode.removeChild(link);
+  }
 });


### PR DESCRIPTION
this adds an option to append a querystring e.g `canonical({ qs: loc.search })`.

cc @ianstormtaylor 
